### PR TITLE
WILL-1485 - Bugfixing LanguageProvider::getHomeUrl()

### DIFF
--- a/src/Helpers/LanguageProvider.php
+++ b/src/Helpers/LanguageProvider.php
@@ -278,11 +278,12 @@ class LanguageProvider
      */
     public static function getHomeUrl(string $path = '', ?string $languageCode = null): string
     {
+        $homeUrl = home_url('');
         if (function_exists('pll_home_url')) {
-            return pll_home_url($languageCode) . $path;
+            $homeUrl = pll_home_url($languageCode);
         }
 
-        return home_url($path);
+        return sprintf('%s/%s', rtrim($homeUrl, '/'), ltrim($path, '/'));
     }
 
     /**

--- a/willow-mu-plugins.php
+++ b/willow-mu-plugins.php
@@ -4,7 +4,7 @@ Plugin Name: Willow Must Use Plugins
 Plugin URI: https://github.com/BenjaminMedia/willow-mu-plugins
 Description: A collection of Must Use WordPress Plugins for Willow
 Author: Bonnier Publications
-Version: 1.4.0
+Version: 1.4.1
 */
 
 new \Bonnier\Willow\MuPlugins\AdminCookie();


### PR DESCRIPTION
Updating LanguageProvider::getHomeUrl() to ensure it does not insert double slash between domain and path.